### PR TITLE
Updated to always require auth token

### DIFF
--- a/armory/armory.go
+++ b/armory/armory.go
@@ -12,11 +12,10 @@ type ArmoryData struct {
 }
 
 var (
-	Authenticated bool
-	GlobalConfig  *config.Config
-	Logger        hclog.Logger
-	Data          ArmoryData
-	Armory        = pluginkit.Armory{
+	GlobalConfig *config.Config
+	Logger       hclog.Logger
+	Data         ArmoryData
+	Armory       = pluginkit.Armory{
 		TestSuites: map[string][]pluginkit.TestSet{
 			"dev": {
 				DO_01,
@@ -87,25 +86,6 @@ var (
 func SetupArmory(c *config.Config) {
 	GlobalConfig = c
 	Logger = c.Logger
-	if c.GetString("token") == "" {
-		Armory.TestSuites = unauthenticatedTestSuites()
-	} else {
-		Authenticated = true
-	}
-}
-
-func unauthenticatedTestSuites() map[string][]pluginkit.TestSet {
-	return map[string][]pluginkit.TestSet{
-		"dev": {
-			QA_01,
-			BR_02,
-			BR_06,
-			LE_04,
-		},
-		"maturity_1": {},
-		"maturity_2": {},
-		"maturity_3": {},
-	}
 }
 
 func (r *ArmoryData) Rest() RestData {

--- a/armory/br-06.go
+++ b/armory/br-06.go
@@ -33,15 +33,9 @@ func BR_06_T02() pluginkit.TestResult {
 		Function:    utils.CallerPath(0),
 	}
 
-	if !Authenticated {
-		// TODO: This could be a REST call, just grab the first releases entry "body" instead of graphql latest "description"
-		testResult.Passed = false
-		testResult.Message = "Not authenticated, cannot continue"
-	} else {
-		releaseDescription := Data.GraphQL().Repository.LatestRelease.Description
-		contains := (strings.Contains(releaseDescription, "Change Log") || strings.Contains(releaseDescription, "Changelog"))
-		testResult.Passed = contains
-		testResult.Message = fmt.Sprintf("Change Log Found in Latest Release: %v", contains)
-	}
+	releaseDescription := Data.GraphQL().Repository.LatestRelease.Description
+	contains := (strings.Contains(releaseDescription, "Change Log") || strings.Contains(releaseDescription, "Changelog"))
+	testResult.Passed = contains
+	testResult.Message = fmt.Sprintf("Change Log Found in Latest Release: %v", contains)
 	return testResult
 }

--- a/armory/data-rest.go
+++ b/armory/data-rest.go
@@ -65,18 +65,13 @@ type WorkflowPermissions struct {
 
 var APIBase = "https://api.github.com/repos"
 
-func makeApiCall(endpoint string, authRequired bool) (body []byte, err error) {
+func makeApiCall(endpoint string) (body []byte, err error) {
 	Logger.Trace(fmt.Sprintf("GET %s", endpoint))
 	request, err := http.NewRequest("GET", endpoint, nil)
 	if err != nil {
 		return nil, err
 	}
-	if authRequired && Authenticated {
-		request.Header.Set("Authorization", "Bearer "+GlobalConfig.GetString("token"))
-	} else if authRequired && !Authenticated {
-		err = fmt.Errorf("auth required but not authenticated")
-		return nil, err
-	}
+	request.Header.Set("Authorization", "Bearer "+GlobalConfig.GetString("token"))
 	client := &http.Client{}
 	response, err := client.Do(request)
 	if err != nil {
@@ -92,7 +87,7 @@ func makeApiCall(endpoint string, authRequired bool) (body []byte, err error) {
 
 func getSourceFile(owner, repo, path string) (response FileAPIResponse, err error) {
 	endpoint := fmt.Sprintf("%s/%s/%s/contents/%s", APIBase, owner, repo, path)
-	responseData, err := makeApiCall(endpoint, false)
+	responseData, err := makeApiCall(endpoint)
 	if err != nil {
 		return
 	}
@@ -157,7 +152,7 @@ func (r *RestData) foundSecurityInsights(content DirContents) bool {
 
 func (r *RestData) getTopDirContents() {
 	endpoint := fmt.Sprintf("%s/%s/%s/contents", APIBase, r.owner, r.repo)
-	responseData, err := makeApiCall(endpoint, false)
+	responseData, err := makeApiCall(endpoint)
 	if err != nil {
 		Logger.Error(fmt.Sprintf("error getting top level contents: %s", err.Error()))
 		return
@@ -167,7 +162,7 @@ func (r *RestData) getTopDirContents() {
 
 func (r *RestData) getForgeDirContents() {
 	endpoint := fmt.Sprintf("%s/%s/%s/contents/.github", APIBase, r.owner, r.repo)
-	responseData, err := makeApiCall(endpoint, false)
+	responseData, err := makeApiCall(endpoint)
 	if err != nil {
 		Logger.Error(fmt.Sprintf("error getting forge contents: %s", err.Error()))
 		return
@@ -177,7 +172,7 @@ func (r *RestData) getForgeDirContents() {
 
 func (r *RestData) getMetadata() error {
 	endpoint := fmt.Sprintf("%s/%s/%s", APIBase, r.owner, r.repo)
-	responseData, err := makeApiCall(endpoint, false)
+	responseData, err := makeApiCall(endpoint)
 	if err != nil {
 		return err
 	}
@@ -186,7 +181,7 @@ func (r *RestData) getMetadata() error {
 
 func (r *RepoData) getReleases(owner, repo string) error {
 	endpoint := fmt.Sprintf("%s/%s/%s/releases", APIBase, owner, repo)
-	responseData, err := makeApiCall(endpoint, false)
+	responseData, err := makeApiCall(endpoint)
 	if err != nil {
 		return err
 	}
@@ -199,7 +194,7 @@ func (r *RestData) getWorkflowPermissions() (WorkflowPermissions, error) {
 	}
 
 	endpoint := fmt.Sprintf("%s/%s/%s/actions/permissions/workflow", APIBase, r.owner, r.repo)
-	responseData, err := makeApiCall(endpoint, true)
+	responseData, err := makeApiCall(endpoint)
 	if err != nil {
 		return WorkflowPermissions{}, err
 	}
@@ -213,7 +208,7 @@ func (r *RestData) getWorkflowPermissions() (WorkflowPermissions, error) {
 }
 
 func getFileContentByURL(downloadURL string) (string, error) {
-	responseData, err := makeApiCall(downloadURL, false)
+	responseData, err := makeApiCall(downloadURL)
 	if err != nil {
 		return "", err
 	}

--- a/armory/do-03.go
+++ b/armory/do-03.go
@@ -37,7 +37,7 @@ func DO_03_T01() pluginkit.TestResult {
 }
 
 func DO_03_T02() pluginkit.TestResult {
-	_, err := makeApiCall(Data.Rest().Insights.Project.Documentation.DetailedGuide, false)
+	_, err := makeApiCall(Data.Rest().Insights.Project.Documentation.DetailedGuide)
 
 	testResult := pluginkit.TestResult{
 		Description: "Verifying that an artifact exists at the location specified for the detailed-guide.",

--- a/armory/do-07.go
+++ b/armory/do-07.go
@@ -36,7 +36,7 @@ func DO_07_T01() pluginkit.TestResult {
 }
 
 func DO_07_T02() pluginkit.TestResult {
-	_, err := makeApiCall(Data.Rest().Insights.Repository.Security.Assessments.Self.Evidence, false)
+	_, err := makeApiCall(Data.Rest().Insights.Repository.Security.Assessments.Self.Evidence)
 
 	testResult := pluginkit.TestResult{
 		Description: "Verifying that an artifact exists at the location specified for the self assessment.",

--- a/armory/do-08.go
+++ b/armory/do-08.go
@@ -38,7 +38,7 @@ func DO_08_T01() pluginkit.TestResult {
 }
 
 func DO_08_T02() pluginkit.TestResult {
-	_, err := makeApiCall(Data.Rest().Insights.Repository.Documentation.DependencyManagement, false)
+	_, err := makeApiCall(Data.Rest().Insights.Repository.Documentation.DependencyManagement)
 
 	testResult := pluginkit.TestResult{
 		Description: "Verifying that an artifact exists at the location specified for the dependency-management policy.",

--- a/armory/do-12.go
+++ b/armory/do-12.go
@@ -40,7 +40,7 @@ func DO_12_T01() pluginkit.TestResult {
 
 func DO_12_T02() pluginkit.TestResult {
 
-	_, err := makeApiCall(Data.Rest().Insights.Project.Documentation.SignatureVerification, true)
+	_, err := makeApiCall(Data.Rest().Insights.Project.Documentation.SignatureVerification)
 
 	testResult := pluginkit.TestResult{
 		Description: "Check if the signature verification guide is accessible via HTTP.",

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ var (
 	RequiredVars = []string{
 		"owner",
 		"repo",
+		"token",
 	}
 
 	runCmd = command.NewPluginCommands(


### PR DESCRIPTION
The OSPS Baseline maintainers have requested that any checks we provide _always require_ authentication. While a small subset of checks may be run without auth, the desire is to avoid enabling end users to use the results as a hammer without prior engagement with maintainers.